### PR TITLE
Add runtime statistics section to job monitor page

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,7 +186,113 @@ jobs:
 
       - name: Generate webpage
         run: |
+          set -euo pipefail
           mkdir -p public
+          runtime_stats=$(python3 <<'PY'
+import statistics
+from pathlib import Path
+
+
+def parse_time_to_seconds(time_str: str) -> int:
+    time_str = time_str.strip()
+    if not time_str or time_str in {"-", "N/A"}:
+        return 0
+
+    days = 0
+    rest = time_str
+    if "-" in rest:
+        day_part, maybe_rest = rest.split("-", 1)
+        if day_part.isdigit():
+            days = int(day_part)
+            rest = maybe_rest
+
+    parts = rest.split(":")
+    try:
+        parts = [int(part) for part in parts]
+    except ValueError:
+        return 0
+
+    hours = minutes = seconds = 0
+    if len(parts) == 3:
+        hours, minutes, seconds = parts
+    elif len(parts) == 2:
+        minutes, seconds = parts
+    elif len(parts) == 1:
+        seconds = parts[0]
+    else:
+        return 0
+
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+
+def format_seconds(value: float) -> str:
+    total_seconds = int(round(value))
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    if days > 0:
+        return f"{days}-{hours:02d}:{minutes:02d}:{seconds:02d}"
+    if hours > 0:
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes}:{seconds:02d}"
+
+
+lines = Path("job_status.txt").read_text(encoding="utf-8").splitlines()
+times = []
+
+for idx, line in enumerate(lines):
+    if line.startswith("===== Detailed Job Table"):
+        pointer = idx + 1
+        while pointer < len(lines) and not lines[pointer].strip():
+            pointer += 1
+        if pointer < len(lines):
+            pointer += 1
+        for row in lines[pointer:]:
+            if row.startswith("====="):
+                break
+            if not row.strip():
+                continue
+            segment = row[143:] if len(row) > 143 else ""
+            time_field = segment.split(None, 1)[0] if segment.strip() else ""
+            if not time_field:
+                continue
+            seconds = parse_time_to_seconds(time_field)
+            if seconds > 0:
+                times.append(seconds)
+        break
+
+if times:
+    times.sort()
+    max_val = times[-1]
+    mean_val = sum(times) / len(times)
+    median_val = statistics.median(times)
+    print("|".join([
+        format_seconds(max_val),
+        format_seconds(mean_val),
+        format_seconds(median_val),
+    ]))
+PY
+)
+
+          runtime_max=""
+          runtime_mean=""
+          runtime_median=""
+          if [ -n "$runtime_stats" ]; then
+            IFS='|' read -r runtime_max runtime_mean runtime_median <<EOF
+$runtime_stats
+EOF
+            {
+              echo "===== Runtime elapsed (nonzero) ====="
+              printf "%-22s %s\n" "Max runtime elapsed:" "$runtime_max"
+              printf "%-22s %s\n" "Mean runtime elapsed:" "$runtime_mean"
+              printf "%-22s %s\n" "Median runtime elapsed:" "$runtime_median"
+              echo ""
+              cat job_status.txt
+            } > job_status_with_stats.txt
+            mv job_status_with_stats.txt job_status.txt
+          fi
+
           epoch_ms=$(date +%s000)
           {
             echo "<!DOCTYPE html>"


### PR DESCRIPTION
## Summary
- parse job_status.txt to compute max, mean, and median runtime elapsed for jobs that have recorded time
- prepend a "Runtime elapsed (nonzero)" section to the generated job_status.txt so the HTML page displays the new statistics alongside existing sections

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d97dd78b008322a946bae0b74ed18c