### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,17 +21,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    if: github.event_name == 'pull_request'
+  actionlint:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Validate workflow files with actionlint
-        uses: rhysd/actionlint@v1
-
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color
   fetch-jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: "*/5 * * * *"  # every 5 minutes
   workflow_dispatch:
@@ -18,7 +21,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate workflow files with actionlint
+        uses: rhysd/actionlint@v1
+
   fetch-jobs:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -329,6 +344,7 @@ jobs:
           path: ./public
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- trigger the GitHub Actions workflow for pull request events targeting master
- add an actionlint job for pull requests
- allow the HPCC fetch job to run on pull requests from this repository while still skipping deployment

## Testing
- not run (workflow changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d9933f567483228ed6b537dbfef273