### PR TITLE
Fix job category parsing to use first a= occurrence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,8 @@ jobs:
 
             # Parse category: ensure first a= is taken
             if [[ "$job_name" == *"a="* ]]; then
-              job_type=$(printf '%s' "$job_name" | sed -n 's/.*a=\([^+[:space:]]*\).*$/\1/p')
+              job_type=${job_name#*a=}
+              job_type=${job_type%%[+[:space:]]*}
               if [[ -n "$job_type" ]]; then
                 category_counts["$job_type"]=$(( ${category_counts["$job_type"]:-0} + 1 ))
                 category_state_counts["$job_type|$category_label"]=$(( ${category_state_counts["$job_type|$category_label"]:-0} + 1 ))


### PR DESCRIPTION
## Summary
- ensure the job category parsing logic takes the first `a=` occurrence when splitting job names
- keep subsequent job statistics aggregation unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9a5abff508322aa4ae7caa2f58f5c